### PR TITLE
Guard logging and storage on non-Apple

### DIFF
--- a/AuroraCore/Sources/AuroraCore/Utilities/Debugging.swift
+++ b/AuroraCore/Sources/AuroraCore/Utilities/Debugging.swift
@@ -6,7 +6,43 @@
 //
 
 import Foundation
+
+#if canImport(os)
 import os
+#else
+/// Minimal stand-in for `OSLogType` on platforms where the `os` module is not
+/// available (for example, Linux Swift toolchains used in CI).
+public enum OSLogType {
+    case debug
+    case info
+    case error
+    case fault
+
+    var label: String {
+        switch self {
+        case .debug:
+            return "DEBUG"
+        case .info:
+            return "INFO"
+        case .error:
+            return "ERROR"
+        case .fault:
+            return "FAULT"
+        }
+    }
+}
+
+/// Lightweight logger that mirrors the API shape of `os.Logger` enough for the
+/// rest of the codebase to compile while emitting readable console output.
+public struct Logger {
+    let subsystem: String
+    let category: String
+
+    func log(level: OSLogType, _ message: String) {
+        print("[\(subsystem)][\(category)][\(level.label)] \(message)")
+    }
+}
+#endif
 
 /// The `CustomLogger` class provides a centralized logging system for the app. It allows for logging messages at different severity levels and categories, as well as enabling or disabling debug logs.
 ///
@@ -74,11 +110,19 @@ public final class CustomLogger {
 
         // Add metadata if available
         if metadata.isEmpty {
+#if canImport(os)
             logger.log(level: level, "\(message, privacy: .public)")
+#else
+            logger.log(level: level, message)
+#endif
         } else {
             let metadataDescription = metadata.map { "\($0.key): \($0.value)" }
                 .joined(separator: ", ")
+#if canImport(os)
             logger.log(level: level, "\(message) [\(metadataDescription)]")
+#else
+            logger.log(level: level, "\(message) [\(metadataDescription)]")
+#endif
         }
     }
 

--- a/AuroraCore/Sources/AuroraCore/Utilities/SecureStorage.swift
+++ b/AuroraCore/Sources/AuroraCore/Utilities/SecureStorage.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+
+#if canImport(Security)
 import Security
 
 /// `SecureStorage` is responsible for securely saving, retrieving, and deleting API keys and base URLs using the Keychain on Apple devices.
@@ -132,3 +134,59 @@ public class SecureStorage {
         deleteBaseURL(for: serviceName)
     }
 }
+#else
+
+/// Linux-compatible fallback implementation that mirrors the Keychain-based
+/// API surface while storing secrets in-memory during the process lifetime.
+/// This allows the Swift Package tests to execute on non-Apple platforms where
+/// the Security framework is unavailable. Values are guarded by a serial queue
+/// to keep access thread-safe, which matches the semantics used by the
+/// Keychain-backed implementation.
+public class SecureStorage {
+    private static var storage: [String: String] = [:]
+    private static let queue = DispatchQueue(label: "com.mutantsoup.AuroraCore.secureStorage")
+
+    private static func apiKeyIdentifier(for serviceName: String) -> String {
+        "\(serviceName)_apiKey"
+    }
+
+    private static func baseURLIdentifier(for serviceName: String) -> String {
+        "\(serviceName)_baseURL"
+    }
+
+    @discardableResult
+    public static func saveAPIKey(_ key: String, for serviceName: String) -> Bool {
+        queue.sync { storage[apiKeyIdentifier(for: serviceName)] = key }
+        return true
+    }
+
+    public static func getAPIKey(for serviceName: String) -> String? {
+        queue.sync { storage[apiKeyIdentifier(for: serviceName)] }
+    }
+
+    public static func deleteAPIKey(for serviceName: String) {
+        queue.sync { _ = storage.removeValue(forKey: apiKeyIdentifier(for: serviceName)) }
+    }
+
+    @discardableResult
+    public static func saveBaseURL(_ url: String, for serviceName: String) -> Bool {
+        queue.sync { storage[baseURLIdentifier(for: serviceName)] = url }
+        return true
+    }
+
+    public static func getBaseURL(for serviceName: String) -> String? {
+        queue.sync { storage[baseURLIdentifier(for: serviceName)] }
+    }
+
+    public static func deleteBaseURL(for serviceName: String) {
+        queue.sync { _ = storage.removeValue(forKey: baseURLIdentifier(for: serviceName)) }
+    }
+
+    public static func clearAll(for serviceName: String) {
+        queue.sync {
+            _ = storage.removeValue(forKey: apiKeyIdentifier(for: serviceName))
+            _ = storage.removeValue(forKey: baseURLIdentifier(for: serviceName))
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a platform-agnostic fallback for CustomLogger when the os module is unavailable
- provide an in-memory SecureStorage implementation when the Security framework cannot be imported

## Testing
- `swift test` *(fails on Linux: missing NaturalLanguage framework)*

------
https://chatgpt.com/codex/tasks/task_e_68f429306438832f91f7d28c9aa7246f